### PR TITLE
feat: add zIndex to modal recipe for improved overlay stacking

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,32 @@
     "panda.config.ts",
     "postcss.config.cjs"
   ],
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "/css": {
+      "types": "./styled-system/css/index.d.ts",
+      "require": "./styled-system/css/index.mjs",
+      "import": "./styled-system/css/index.mjs"
+    },
+    "/recipes": {
+      "types": "./styled-system/recipes/index.d.ts",
+      "require": "./styled-system/recipes/index.mjs",
+      "import": "./styled-system/recipes/index.mjs"
+    },
+    "/patterns": {
+      "types": "./styled-system/patterns/index.d.ts",
+      "require": "./styled-system/patterns/index.mjs",
+      "import": "./styled-system/patterns/index.mjs"
+    },
+    "/jsx": {
+      "types": "./styled-system/jsx/index.d.ts",
+      "require": "./styled-system/jsx/index.mjs",
+      "import": "./styled-system/jsx/index.mjs"
+    }
+  },
   "scripts": {
     "prepare": "panda codegen && husky",
     "postinstall": "panda codegen",
@@ -25,7 +51,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "paraglide": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide",
-    "machine-translate": "inlang machine translate --project project.inlang"
+    "machine-translate": "inlang machine translate --project project.inlang",
+    "cssgen": "panda cssgen -o dist/lib.css"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "paraglide": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide",
-    "machine-translate": "inlang machine translate --project project.inlang",
-    "cssgen": "panda cssgen -o dist/lib.css"
+    "machine-translate": "inlang machine translate --project project.inlang"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -31,4 +31,7 @@ export default defineConfig({
 
   // Files to exclude
   exclude: [],
+
+  // The output directory for your css system
+  outdir: 'styled-system',
 });

--- a/src/overlay/modal.recipe.ts
+++ b/src/overlay/modal.recipe.ts
@@ -17,6 +17,7 @@ export const modalRecipe = defineSlotRecipe({
       position: "fixed",
       inset: "0",
       backgroundColor: "overlay",
+      zIndex: "100",
 
       /* Gives the blur to the content below the overlay */
       backdropFilter: "auto",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configures package subpath exports for `styled-system`, sets Panda CSS `outdir`, and adds `zIndex` to the modal overlay.
> 
> - **Build/Packaging**:
>   - Add subpath `exports` in `package.json` for `./`, `/css`, `/recipes`, `/patterns`, and `/jsx` pointing to `styled-system` outputs and types.
>   - Configure Panda CSS output directory with `outdir: 'styled-system'` in `panda.config.ts`.
> - **UI**:
>   - Modal overlay recipe: add `zIndex: "100"` to `src/overlay/modal.recipe.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b78c258764041df1ae261e263300b37bc53c26d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->