### PR TITLE
fix: tab

### DIFF
--- a/src/cci-preset.ts
+++ b/src/cci-preset.ts
@@ -87,6 +87,7 @@ export const cciPreset = definePreset({
       radioGroup: radioGroupRecipe,
       select: selectRecipe,
       table: tableRecipe,
+      tab: tabRecipe,
       tagGroup: tagGroupRecipe,
       empty: emptyRecipe,
 
@@ -108,7 +109,6 @@ export const cciPreset = definePreset({
       tableHeader: tableHeaderRecipe,
       heading: headingRecipe,
       text: textRecipe,
-      tab: tabRecipe,
     },
 
     // extend: {

--- a/src/tab/Tab.stories.tsx
+++ b/src/tab/Tab.stories.tsx
@@ -22,19 +22,25 @@ type Story = StoryObj<typeof Tabs>;
 
 export const Default: Story = {
   render: () => (
-    <Tabs defaultSelectedKey="tab1">
-      <TabList aria-label="Sample Tabs">
-        <Tab id="tab1">Tab 1</Tab>
-        <Tab id="tab2">Tab 2</Tab>
-        <Tab id="tab3">Tab 3</Tab>
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="start">
+      <TabList variant="line" size="md" color="primary" align="start" aria-label="Sample Tabs">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
       </TabList>
-      <TabPanel id="tab1">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab1">
         <Paragraph>Content for Tab 1</Paragraph>
       </TabPanel>
-      <TabPanel id="tab2">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab2">
         <Paragraph>Content for Tab 2</Paragraph>
       </TabPanel>
-      <TabPanel id="tab3">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab3">
         <Paragraph>Content for Tab 3</Paragraph>
       </TabPanel>
     </Tabs>
@@ -43,21 +49,25 @@ export const Default: Story = {
 
 export const WithDisabledTab: Story = {
   render: () => (
-    <Tabs defaultSelectedKey="tab1">
-      <TabList aria-label="Tabs with Disabled Tab">
-        <Tab id="tab1">Tab 1</Tab>
-        <Tab id="tab2">Tab 2</Tab>
-        <Tab id="tab3" isDisabled>
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="start">
+      <TabList variant="line" size="md" color="primary" align="start" aria-label="Tabs with Disabled Tab">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab3" isDisabled>
           Tab 3 (Disabled)
         </Tab>
       </TabList>
-      <TabPanel id="tab1">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab1">
         <Paragraph>Content for Tab 1</Paragraph>
       </TabPanel>
-      <TabPanel id="tab2">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab2">
         <Paragraph>Content for Tab 2</Paragraph>
       </TabPanel>
-      <TabPanel id="tab3">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab3">
         <Paragraph>Content for Tab 3</Paragraph>
       </TabPanel>
     </Tabs>
@@ -66,35 +76,359 @@ export const WithDisabledTab: Story = {
 
 export const WithCustomContent: Story = {
   render: () => (
-    <Tabs defaultSelectedKey="tab1">
-      <TabList aria-label="Tabs with Custom Content">
-        <Tab id="tab1">
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="start">
+      <TabList variant="line" size="md" color="primary" align="start" aria-label="Tabs with Custom Content">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab1">
           <span role="img" aria-label="star">
             ⭐
           </span>{" "}
           Tab 1
         </Tab>
-        <Tab id="tab2">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab2">
           <span role="img" aria-label="heart">
             ❤️
           </span>{" "}
           Tab 2
         </Tab>
-        <Tab id="tab3">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab3">
           <span role="img" aria-label="rocket">
             🚀
           </span>{" "}
           Tab 3
         </Tab>
       </TabList>
-      <TabPanel id="tab1">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab1">
         <Paragraph>Custom content for Tab 1</Paragraph>
       </TabPanel>
-      <TabPanel id="tab2">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab2">
         <Paragraph>Custom content for Tab 2</Paragraph>
       </TabPanel>
-      <TabPanel id="tab3">
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab3">
         <Paragraph>Custom content for Tab 3</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const VariantLine: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="start">
+      <TabList variant="line" size="md" color="primary" align="start" aria-label="Line Variant Tabs">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with line variant</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with line variant</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with line variant</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const VariantEnclosed: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="enclosed" size="md" color="primary" align="start">
+      <TabList variant="enclosed" size="md" color="primary" align="start" aria-label="Enclosed Variant Tabs">
+        <Tab variant="enclosed" size="md" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="enclosed" size="md" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="enclosed" size="md" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="enclosed" size="md" color="primary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with enclosed variant</Paragraph>
+      </TabPanel>
+      <TabPanel variant="enclosed" size="md" color="primary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with enclosed variant</Paragraph>
+      </TabPanel>
+      <TabPanel variant="enclosed" size="md" color="primary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with enclosed variant</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const VariantUnstyled: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="unstyled" size="md" color="primary" align="start">
+      <TabList variant="unstyled" size="md" color="primary" align="start" aria-label="Unstyled Variant Tabs">
+        <Tab variant="unstyled" size="md" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="unstyled" size="md" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="unstyled" size="md" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="unstyled" size="md" color="primary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with unstyled variant</Paragraph>
+      </TabPanel>
+      <TabPanel variant="unstyled" size="md" color="primary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with unstyled variant</Paragraph>
+      </TabPanel>
+      <TabPanel variant="unstyled" size="md" color="primary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with unstyled variant</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const SizeSmall: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="sm" color="primary" align="start">
+      <TabList variant="line" size="sm" color="primary" align="start" aria-label="Small Size Tabs">
+        <Tab variant="line" size="sm" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="sm" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="sm" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="sm" color="primary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with small size</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="sm" color="primary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with small size</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="sm" color="primary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with small size</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const SizeMedium: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="start">
+      <TabList variant="line" size="md" color="primary" align="start" aria-label="Medium Size Tabs">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with medium size</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with medium size</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with medium size</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const SizeLarge: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="lg" color="primary" align="start">
+      <TabList variant="line" size="lg" color="primary" align="start" aria-label="Large Size Tabs">
+        <Tab variant="line" size="lg" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="lg" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="lg" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="lg" color="primary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with large size</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="lg" color="primary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with large size</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="lg" color="primary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with large size</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const ColorPrimary: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="start">
+      <TabList variant="line" size="md" color="primary" align="start" aria-label="Primary Color Tabs">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with primary color</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with primary color</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with primary color</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const ColorSecondary: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="secondary" align="start">
+      <TabList variant="line" size="md" color="secondary" align="start" aria-label="Secondary Color Tabs">
+        <Tab variant="line" size="md" color="secondary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="secondary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="secondary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="md" color="secondary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with secondary color</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="secondary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with secondary color</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="secondary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with secondary color</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const AlignStart: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="start">
+      <TabList variant="line" size="md" color="primary" align="start" aria-label="Start Aligned Tabs">
+        <Tab variant="line" size="md" color="primary" align="start" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="start" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab1">
+        <Paragraph>Content for Tab 1 with start alignment</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab2">
+        <Paragraph>Content for Tab 2 with start alignment</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="start" id="tab3">
+        <Paragraph>Content for Tab 3 with start alignment</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const AlignCenter: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="center">
+      <TabList variant="line" size="md" color="primary" align="center" aria-label="Center Aligned Tabs">
+        <Tab variant="line" size="md" color="primary" align="center" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="center" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="center" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="md" color="primary" align="center" id="tab1">
+        <Paragraph>Content for Tab 1 with center alignment</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="center" id="tab2">
+        <Paragraph>Content for Tab 2 with center alignment</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="center" id="tab3">
+        <Paragraph>Content for Tab 3 with center alignment</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const AlignEnd: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="line" size="md" color="primary" align="end">
+      <TabList variant="line" size="md" color="primary" align="end" aria-label="End Aligned Tabs">
+        <Tab variant="line" size="md" color="primary" align="end" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="end" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="line" size="md" color="primary" align="end" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="line" size="md" color="primary" align="end" id="tab1">
+        <Paragraph>Content for Tab 1 with end alignment</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="end" id="tab2">
+        <Paragraph>Content for Tab 2 with end alignment</Paragraph>
+      </TabPanel>
+      <TabPanel variant="line" size="md" color="primary" align="end" id="tab3">
+        <Paragraph>Content for Tab 3 with end alignment</Paragraph>
+      </TabPanel>
+    </Tabs>
+  ),
+};
+
+export const CombinedVariants: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="tab1" variant="enclosed" size="lg" color="secondary" align="center">
+      <TabList variant="enclosed" size="lg" color="secondary" align="center" aria-label="Combined Variants Tabs">
+        <Tab variant="enclosed" size="lg" color="secondary" align="center" id="tab1">
+          Tab 1
+        </Tab>
+        <Tab variant="enclosed" size="lg" color="secondary" align="center" id="tab2">
+          Tab 2
+        </Tab>
+        <Tab variant="enclosed" size="lg" color="secondary" align="center" id="tab3">
+          Tab 3
+        </Tab>
+      </TabList>
+      <TabPanel variant="enclosed" size="lg" color="secondary" align="center" id="tab1">
+        <Paragraph>Content for Tab 1 with combined variants (enclosed, large, secondary, center)</Paragraph>
+      </TabPanel>
+      <TabPanel variant="enclosed" size="lg" color="secondary" align="center" id="tab2">
+        <Paragraph>Content for Tab 2 with combined variants (enclosed, large, secondary, center)</Paragraph>
+      </TabPanel>
+      <TabPanel variant="enclosed" size="lg" color="secondary" align="center" id="tab3">
+        <Paragraph>Content for Tab 3 with combined variants (enclosed, large, secondary, center)</Paragraph>
       </TabPanel>
     </Tabs>
   ),

--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -2,12 +2,12 @@ import { Tab as AriaTab } from "react-aria-components";
 
 import { cx } from "../../styled-system/css";
 import { tab } from "../../styled-system/recipes/tab";
-import { WithoutClassName } from "../types";
 
 import type { FC } from "react";
 import type { TabProps as AriaTabProps } from "react-aria-components";
 
 import type { TabVariantProps } from "../../styled-system/recipes";
+import type { WithoutClassName } from "../types";
 
 export type TabProps = WithoutClassName<AriaTabProps> & Partial<TabVariantProps>;
 

--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -2,10 +2,10 @@ import { Tab as AriaTab } from "react-aria-components";
 
 import { cx } from "../../styled-system/css";
 import { tab } from "../../styled-system/recipes/tab";
+import { WithoutClassName } from "../types";
 
 import type { FC } from "react";
 import type { TabProps as AriaTabProps } from "react-aria-components";
-import type { WithoutClassName } from "src/types";
 
 import type { TabVariantProps } from "../../styled-system/recipes";
 

--- a/src/tab/tab.recipe.ts
+++ b/src/tab/tab.recipe.ts
@@ -101,6 +101,10 @@ export const tabRecipe = defineSlotRecipe({
     variant: {
       line: {
         tab: {
+          borderTopWidth: "0",
+          borderLeftWidth: "0",
+          borderRightWidth: "0",
+          borderRadius: "none",
           borderBottomWidth: "1",
           borderBottomStyle: "solid",
           borderBottomColor: "border.secondary",
@@ -126,8 +130,10 @@ export const tabRecipe = defineSlotRecipe({
       unstyled: {
         tab: {
           border: "none",
+          borderWidth: "0",
+          borderRadius: "none",
           _selected: {
-            color: "text.brand",
+            color: "bg.brand.primary",
           },
         },
       },
@@ -139,7 +145,7 @@ export const tabRecipe = defineSlotRecipe({
         tab: {
           color: "text.primary",
           _selected: {
-            color: "text.brand",
+            color: "bg.brand.primary",
           },
         },
       },
@@ -147,7 +153,7 @@ export const tabRecipe = defineSlotRecipe({
         tab: {
           color: "text.secondary",
           _selected: {
-            color: "text.brand",
+            color: "bg.brand.primary",
           },
         },
       },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Registers `tab` as a slot recipe in the preset, refines tab styling (variants/colors), and expands Storybook examples to cover variants, sizes, colors, and alignment.
> 
> - **Design System / Preset (`src/cci-preset.ts`)**
>   - Register `tab` under `slotRecipes` and remove it from `recipes`.
> - **Tab Styling (`src/tab/tab.recipe.ts`)**
>   - Variant `line`: remove top/left/right borders, set `borderRadius: none`.
>   - Variant `unstyled`: remove borders, set `borderRadius: none`, change `_selected` color to `bg.brand.primary`.
>   - Color schemes: change `_selected` color to `bg.brand.primary` for `primary` and `secondary`.
> - **Component (`src/tab/Tab.tsx`)**
>   - Fix `WithoutClassName` import path; no functional change.
> - **Storybook (`src/tab/Tab.stories.tsx`)**
>   - Add explicit `variant/size/color/align` props to `Tabs`, `TabList`, `Tab`, and `TabPanel`.
>   - Add stories showcasing variants (line/enclosed/unstyled), sizes (sm/md/lg), colors (primary/secondary), and alignment (start/center/end), plus a combined-variants example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ae9b3b6127bfd42bd84d43745f73e4abe3990a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->