### PR TITLE
fix: update import path for WithoutClassName type in Tab components

### DIFF
--- a/src/tab/TabList.tsx
+++ b/src/tab/TabList.tsx
@@ -5,9 +5,9 @@ import { tab } from "../../styled-system/recipes/tab";
 
 import type { ComponentProps, FC } from "react";
 import type { TabListProps as AriaTabListProps } from "react-aria-components";
-import type { WithoutClassName } from "../types";
 
 import type { TabVariantProps } from "../../styled-system/recipes";
+import type { WithoutClassName } from "../types";
 
 export type TabListProps = WithoutClassName<AriaTabListProps<ComponentProps<"div">>> & Partial<TabVariantProps>;
 

--- a/src/tab/TabList.tsx
+++ b/src/tab/TabList.tsx
@@ -5,7 +5,7 @@ import { tab } from "../../styled-system/recipes/tab";
 
 import type { ComponentProps, FC } from "react";
 import type { TabListProps as AriaTabListProps } from "react-aria-components";
-import type { WithoutClassName } from "src/types";
+import type { WithoutClassName } from "../types";
 
 import type { TabVariantProps } from "../../styled-system/recipes";
 

--- a/src/tab/TabPanel.tsx
+++ b/src/tab/TabPanel.tsx
@@ -5,9 +5,9 @@ import { tab } from "../../styled-system/recipes/tab";
 
 import type { FC } from "react";
 import type { TabPanelProps as AriaTabPanelProps } from "react-aria-components";
-import type { WithoutClassName } from "../types";
 
 import type { TabVariantProps } from "../../styled-system/recipes";
+import type { WithoutClassName } from "../types";
 
 export type TabPanelProps = WithoutClassName<AriaTabPanelProps> & Partial<TabVariantProps>;
 

--- a/src/tab/TabPanel.tsx
+++ b/src/tab/TabPanel.tsx
@@ -5,7 +5,7 @@ import { tab } from "../../styled-system/recipes/tab";
 
 import type { FC } from "react";
 import type { TabPanelProps as AriaTabPanelProps } from "react-aria-components";
-import type { WithoutClassName } from "src/types";
+import type { WithoutClassName } from "../types";
 
 import type { TabVariantProps } from "../../styled-system/recipes";
 

--- a/src/tab/Tabs.tsx
+++ b/src/tab/Tabs.tsx
@@ -5,7 +5,7 @@ import { tab } from "../../styled-system/recipes/tab";
 
 import type { FC } from "react";
 import type { TabsProps as AriaTabsProps } from "react-aria-components";
-import type { WithoutClassName } from "src/types";
+import type { WithoutClassName } from "../types";
 
 import type { TabVariantProps } from "../../styled-system/recipes";
 

--- a/src/tab/Tabs.tsx
+++ b/src/tab/Tabs.tsx
@@ -5,9 +5,9 @@ import { tab } from "../../styled-system/recipes/tab";
 
 import type { FC } from "react";
 import type { TabsProps as AriaTabsProps } from "react-aria-components";
-import type { WithoutClassName } from "../types";
 
 import type { TabVariantProps } from "../../styled-system/recipes";
+import type { WithoutClassName } from "../types";
 
 export type TabsProps = WithoutClassName<AriaTabsProps> & Partial<TabVariantProps>;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `WithoutClassName` import to `../types` across `TabList.tsx`, `TabPanel.tsx`, and `Tabs.tsx`.
> 
> - **Tabs package**:
>   - Update `WithoutClassName` import path from `src/types` to `../types` in:
>     - `src/tab/TabList.tsx`
>     - `src/tab/TabPanel.tsx`
>     - `src/tab/Tabs.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6850eeda5860b1686d2ae58d0e9937ae21f9ade. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->