### PR TITLE
feat: added form errors with RAC and Tanstack Form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carvajalconsultants/ui-primitives",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "repository": "git@github.com:carvajalconsultants/ui-primitives.git",
   "author": "Carvajal Consultants, Inc. <support@carvajalonline.com>",
   "license": "MIT",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { DialogTrigger } from "react-aria-components";
 
+import * as v from "valibot";
+
 import { css } from "../styled-system/css";
 import { Box, HStack, Stack } from "../styled-system/jsx";
 import { Avatar } from "./avatar/Avatar";
@@ -96,7 +98,16 @@ export const App = () => {
   const form = useAppForm({
     defaultValues: {
       firstName: "John",
-      lastName: "Doe",
+      emailAddress: "john@doecom",
+    },
+    validators: {
+      onSubmit: v.object({
+        firstName: v.pipe(v.string(), v.nonEmpty("Please enter your name.")),
+        emailAddress: v.pipe(v.string(), v.email("Please enter a valid e-mail address.")),
+      }),
+    },
+    onSubmit: ({ value: { firstName, emailAddress } }) => {
+      alert(`Sending to ${firstName} at ${emailAddress}`);
     },
   });
 
@@ -117,7 +128,14 @@ export const App = () => {
       }}>
       {/* Temporary <Icon> fix */}
       <Box width="4" height="4" bg="primary.foreground" />
-      <form.AppField name="firstName">{(field) => <field.TextField label="First Name" />}</form.AppField>
+      <Heading>Form Test</Heading>
+      <form.AppForm>
+        <form.Element>
+          <form.AppField name="firstName">{(field) => <field.TextField name={field.name} label="First Name" />}</form.AppField>
+          <form.AppField name="emailAddress">{(field) => <field.TextField name={field.name} label="E-mail" />}</form.AppField>
+          <Button type="submit">Test it</Button>
+        </form.Element>
+      </form.AppForm>
 
       <Tabs defaultSelectedKey="tab1">
         <TabList aria-label="Tabs with Disabled Tab">

--- a/src/form/Form.tsx
+++ b/src/form/Form.tsx
@@ -1,0 +1,118 @@
+import { Form as AriaForm } from "react-aria-components";
+
+import { useFormContext } from "./context";
+
+import type { ValidationErrors } from "@react-types/shared";
+import type { StandardSchemaV1Issue } from "@tanstack/react-form";
+import type { FormEvent } from "react";
+import type { FormProps } from "react-aria-components";
+
+/**
+ * Converts TanStack React Form error objects into the format expected
+ * by React Aria (`ValidationErrors`).
+ *
+ * Real-world purpose:
+ * - React Aria requires a very specific `Record<string, string[]>` structure
+ *   for errors so it can associate them with accessible form elements.
+ * - TanStack Form, on the other hand, groups issues by field but wraps them
+ *   in schema-based validation arrays.
+ *
+ * This utility acts as a “translator” between the two systems so our form
+ * ecosystem remains fully accessible while still benefiting from TanStack’s
+ * deeply typed validation layer.
+ *
+ * @param errors — Array of error bag objects coming from TanStack Form state
+ * @returns ValidationErrors — The normalized error object for React Aria
+ */
+const ariaErrors = (errors: unknown[]): ValidationErrors => {
+  const validationErrors: ValidationErrors = {};
+
+  errors.forEach((error) => {
+    if (!error) return;
+
+    for (const [key, value] of Object.entries(error)) {
+      /**
+       * Real-world description:
+       * - `value` is an array of validation issues (StandardSchemaV1Issue[]).
+       * - Each issue contains a `message` describing what went wrong.
+       * - We map the list of issues to a string[] for React Aria.
+       *
+       * We use loose typing here intentionally because TanStack Form exposes
+       * validation issues in a generic but dynamic structure.
+       */
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      validationErrors[key] = value.map((issue: StandardSchemaV1Issue) => issue.message);
+    }
+  });
+
+  return validationErrors;
+};
+
+/**
+ * A unified `<Form>` component that bridges:
+ *  - TanStack React Form (business logic, validation, submission)
+ *  - React Aria (accessibility, form semantics, focus management)
+ *
+ * Real-world problem this solves:
+ * - TanStack Form gives us typed validation, schema integration, and reactive form state.
+ * - React Aria provides accessible form primitives (ARIA roles, announcements, etc.).
+ * - These two libraries are not natively compatible in how they handle errors and submission.
+ *
+ * This wrapper harmonizes both systems so our forms:
+ *  - Stay fully accessible (React Aria)
+ *  - Stay fully typed and validation-first (TanStack Form)
+ *  - Have a clean API for our internal form components
+ *
+ * @param props — All React Aria `<Form>` props except `onSubmit` and `validationErrors`
+ *                since we override both to integrate with TanStack Form.
+ *
+ * @returns JSX.Element — A React Aria `<Form>` synchronized with TanStack Form state.
+ */
+export const Form = (props: Omit<FormProps, "onSubmit" | "validationErrors">) => {
+  const form = useFormContext();
+
+  /**
+   * Handles form submission using TanStack's internal submission logic.
+   *
+   * Real-world behavior:
+   * - Prevents default browser submission behavior.
+   * - Calls TanStack Form's `handleSubmit`, which:
+   *   ✓ Runs schema validation
+   *   ✓ Updates form state
+   *   ✓ Executes user-defined submit handlers
+   * - Wrapping in `void` suppresses the promise return for event handlers.
+   */
+  const submitHandler = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void form.handleSubmit();
+  };
+
+  return (
+    /**
+     * `form.Subscribe` lets us track TanStack Form's error state reactively.
+     * Whenever validation errors change, React Aria re-renders with the updated
+     * error map — ensuring instant accessibility feedback.
+     *
+     * The selector `(state) => state.errors` extracts only the error object
+     * to minimize rerenders and improve performance.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    <form.Subscribe selector={(state) => state.errors}>
+      {(errors) => (
+        <AriaForm
+          {...props}
+          /**
+           * The unified submit handler that ensures TanStack Form drives the
+           * submission pipeline.
+           */
+          onSubmit={submitHandler}
+          /**
+           * React Aria uses this prop to associate error messages with fields.
+           * We convert TanStack Form’s validation structure into this format.
+           */
+          validationErrors={ariaErrors(errors)}
+        />
+      )}
+    </form.Subscribe>
+  );
+};

--- a/src/form/context.ts
+++ b/src/form/context.ts
@@ -1,0 +1,16 @@
+import { createFormHookContexts } from "@tanstack/react-form";
+
+/**
+ * Form context objects used for managing form state and field interactions.
+ * @typedef {Object} FormContexts
+ * @property {React.Context} fieldContext - Context for individual form field state and behaviors
+ * @property {React.Context} formContext - Context for overall form state management
+ * @property {Function} useFieldContext - Hook to access field context within custom form components
+ *
+ * These contexts enable:
+ * - Consistent form state management across complex forms
+ * - Field-level validation and error handling
+ * - Custom form field component creation
+ * - Form-wide operations like reset, submit, and validation
+ */
+export const { fieldContext, formContext, useFieldContext, useFormContext } = createFormHookContexts();

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -1,24 +1,13 @@
-import { createFormHook, createFormHookContexts } from "@tanstack/react-form";
+import { createFormHook } from "@tanstack/react-form";
 
+import { fieldContext, formContext } from "./context";
 import { FormSearchField } from "./field/FormSearchField";
 import { FormSliderField } from "./field/FormSliderField";
 import { FormSwitchField } from "./field/FormSwitchField";
 import { FormTextField } from "./field/FormTextField";
+import { Form } from "./Form";
 
-/**
- * Form context objects used for managing form state and field interactions.
- * @typedef {Object} FormContexts
- * @property {React.Context} fieldContext - Context for individual form field state and behaviors
- * @property {React.Context} formContext - Context for overall form state management
- * @property {Function} useFieldContext - Hook to access field context within custom form components
- *
- * These contexts enable:
- * - Consistent form state management across complex forms
- * - Field-level validation and error handling
- * - Custom form field component creation
- * - Form-wide operations like reset, submit, and validation
- */
-export const { fieldContext, formContext, useFieldContext } = createFormHookContexts();
+export { fieldContext, formContext, useFieldContext, useFormContext } from "./context";
 
 /**
  * Custom form hook and HOC creator configured with our form field components.
@@ -41,7 +30,7 @@ export const { fieldContext, formContext, useFieldContext } = createFormHookCont
  * - SliderField: Numeric input with visual slider control
  * - SwitchField: Toggle input for boolean values
  */
-export const { useAppForm, withForm } = createFormHook({
+export const { useAppForm, withForm, withFieldGroup } = createFormHook({
   fieldContext,
   formContext,
   fieldComponents: {
@@ -50,5 +39,7 @@ export const { useAppForm, withForm } = createFormHook({
     SliderField: FormSliderField,
     SwitchField: FormSwitchField,
   },
-  formComponents: {},
+  formComponents: {
+    Element: Form,
+  },
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a `Form` component that maps TanStack Form errors to React Aria and update the demo to use validated fields with `valibot`.
> 
> - **Form system**:
>   - **New `src/form/Form.tsx`**: Wrapper around React Aria `Form` that subscribes to TanStack Form errors, converts them to `ValidationErrors`, and handles submit via `handleSubmit`.
>   - **Context refactor**: Move contexts to `src/form/context.ts`; re-export `fieldContext`, `formContext`, `useFieldContext`, `useFormContext` from `index`.
>   - **Hook API**: Update `createFormHook` to expose `withFieldGroup` and register `Form` as `formComponents.Element`.
> - **App demo**:
>   - Integrate `valibot` validators and `onSubmit` handler in `useAppForm`.
>   - Replace single field with `form.AppForm` + `form.Element` and two fields (`firstName`, `emailAddress`); remove `lastName`, add `Heading`.
> - **Version**: Bump package to `0.0.37`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35069aa35ce21a156f6f4893dbc69ee9b4794f30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->