### PR TITLE
feat: add OTPTextField component to cciPreset and export in index

### DIFF
--- a/src/cci-preset.ts
+++ b/src/cci-preset.ts
@@ -8,6 +8,7 @@ import { comboBoxRecipe } from "./combobox/comboBox.recipe";
 import { labelRecipe } from "./common/label.recipe";
 import { datePickerRecipe } from "./datepicker/datePicker.recipe";
 import { inputRecipe } from "./field/input.recipe";
+import { otpTextFieldRecipe } from "./field/otpTextField.recipe";
 import { sliderRecipe } from "./field/slider.recipe";
 import { switchRecipe } from "./field/switch.recipe";
 import { listBoxRecipe } from "./listbox/listBox.recipe";
@@ -79,6 +80,7 @@ export const cciPreset = definePreset({
       comboBox: comboBoxRecipe,
       datePicker: datePickerRecipe,
       input: inputRecipe,
+      otpTextField: otpTextFieldRecipe,
       slider: sliderRecipe,
       dialog: dialogRecipe,
       modal: modalRecipe,

--- a/src/field/OTPTextField.stories.tsx
+++ b/src/field/OTPTextField.stories.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+
+import { Button } from "../button/Button";
+import { OTPTextField } from "./OTPTextField";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof OTPTextField> = {
+  title: "Components/OTPTextField",
+  component: OTPTextField,
+
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof OTPTextField>;
+
+const ControlledOTPTextField = () => {
+  const [value, setValue] = useState("");
+
+  return (
+    <OTPTextField
+      name="otpCode"
+      value={value}
+      onChange={(newValue) => {
+        const limitedValue = newValue.slice(0, 6).replace(/\D/g, "");
+        setValue(limitedValue);
+      }}
+      pattern="^\\d+$"
+    />
+  );
+};
+
+const DefaultStory: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px", marginTop: "30px", gap: "22px", padding: "40px 30px" }}>
+      <ControlledOTPTextField />
+    </div>
+  ),
+};
+
+export const Default = {
+  ...DefaultStory,
+};
+
+const PartialValueComponent = () => {
+  const [value, setValue] = useState("123");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px", marginTop: "30px", gap: "22px", padding: "40px 30px" }}>
+      <OTPTextField
+        name="otpCode"
+        value={value}
+        onChange={(newValue) => {
+          const limitedValue = newValue.slice(0, 6).replace(/\D/g, "");
+          setValue(limitedValue);
+        }}
+        pattern="^\\d+$"
+      />
+    </div>
+  );
+};
+
+const PartialValueStory: Story = {
+  render: () => <PartialValueComponent />,
+};
+
+export const PartialValue = {
+  ...PartialValueStory,
+};
+
+const CompleteValueComponent = () => {
+  const [value, setValue] = useState("123456");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px", marginTop: "30px", gap: "22px", padding: "40px 30px" }}>
+      <OTPTextField
+        name="otpCode"
+        value={value}
+        onChange={(newValue) => {
+          const limitedValue = newValue.slice(0, 6).replace(/\D/g, "");
+          setValue(limitedValue);
+        }}
+        pattern="^\\d+$"
+      />
+    </div>
+  );
+};
+
+const CompleteValueStory: Story = {
+  render: () => <CompleteValueComponent />,
+};
+
+export const CompleteValue = {
+  ...CompleteValueStory,
+};
+
+const DisabledComponent = () => {
+  const [value, setValue] = useState("123456");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px", marginTop: "30px", gap: "22px", padding: "40px 30px" }}>
+      <OTPTextField
+        name="otpCode"
+        value={value}
+        onChange={(newValue) => {
+          const limitedValue = newValue.slice(0, 6).replace(/\D/g, "");
+          setValue(limitedValue);
+        }}
+        pattern="^\\d+$"
+        isDisabled
+      />
+    </div>
+  );
+};
+
+const DisabledStory: Story = {
+  render: () => <DisabledComponent />,
+};
+
+export const Disabled = {
+  ...DisabledStory,
+};
+
+const FormIntegrationComponent = () => {
+  const [value, setValue] = useState("");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px", marginTop: "30px", gap: "22px", padding: "40px 30px" }}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          alert(`OTP Code: ${value}`);
+        }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <OTPTextField
+            name="otpCode"
+            value={value}
+            onChange={(newValue) => {
+              const limitedValue = newValue.slice(0, 6).replace(/\D/g, "");
+              setValue(limitedValue);
+            }}
+            pattern="^\\d+$"
+          />
+          <Button type="submit" width="full" variant="secondary">
+            Submit
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+const FormIntegrationStory: Story = {
+  render: () => <FormIntegrationComponent />,
+};
+
+export const FormIntegration = {
+  ...FormIntegrationStory,
+};

--- a/src/field/OTPTextField.tsx
+++ b/src/field/OTPTextField.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import { TextField as AriaTextField, Input } from "react-aria-components";
+
+import { css } from "../../styled-system/css";
+import { otpTextField } from "../../styled-system/recipes";
+import { OTPVisualDisplay } from "./OTPVisualDisplay";
+
+import type { TextFieldProps as AriaTextFieldProps } from "react-aria-components";
+
+import type { WithoutClassName } from "../types";
+
+/**
+ * Props for OTPTextField component
+ */
+export type OTPTextFieldProps = WithoutClassName<AriaTextFieldProps> & {
+  /**
+   * The name of the input field
+   */
+  name: string;
+
+  /**
+   * The current value of the input (6-digit string)
+   */
+  value: string;
+
+  /**
+   * Callback fired when the value changes
+   */
+  onChange: (value: string) => void;
+
+  /**
+   * Pattern for validation (e.g., "^\\d+$" for digits only)
+   */
+  pattern?: string;
+
+  /**
+   * Whether the input is disabled
+   */
+  isDisabled?: boolean;
+};
+
+/**
+ * OTPTextField provides a custom OTP input component with visual digit boxes.
+ *
+ * Uses a single hidden input field that manages all 6 digits as one string value, while
+ * displaying them in separate visual boxes. This enables paste support, better accessibility,
+ * and mobile keyboard optimization. Focus prevention logic prevents the hidden input from
+ * stealing focus during form submission.
+ */
+export const OTPTextField = ({ name, value, onChange, pattern, isDisabled }: OTPTextFieldProps) => {
+  const [focused, setFocused] = useState(false);
+  const styles = otpTextField();
+
+  /**
+   * Blurs the input if it's currently focused.
+   *
+   * Used to prevent unwanted focus during form submission or browser validation.
+   * The setTimeout ensures we check focus state after the browser's default focus
+   * behavior has completed, allowing us to override it if needed.
+   */
+  const blurIfFocused = (input: HTMLInputElement) => {
+    setTimeout(() => {
+      if (document.activeElement === input) {
+        input.blur();
+      }
+    }, 0);
+  };
+
+  /**
+   * Checks if the form is currently submitting by checking if submit button is disabled.
+   *
+   * When the form is submitting, the submit button is disabled. We use this as a signal
+   * to prevent the hidden input from receiving focus during submission, which would
+   * interrupt the user experience.
+   */
+  const isFormSubmitting = (): boolean => {
+    const submitButton = document.querySelector('button[type="submit"]');
+
+    return submitButton instanceof HTMLButtonElement ? submitButton.disabled : false;
+  };
+
+  /**
+   * Triggers form submission by programmatically clicking the submit button.
+   *
+   * Used when user presses Enter in the OTP input. Instead of letting the input submit
+   * the form directly (which could cause focus issues), we delegate to the submit button
+   * which handles form submission properly through react-form.
+   */
+  const triggerFormSubmit = () => {
+    const submitButton = document.querySelector('button[type="submit"]');
+    if (submitButton instanceof HTMLButtonElement && !submitButton.disabled) {
+      submitButton.click();
+    }
+  };
+
+  return (
+    <AriaTextField name={name} value={value} onChange={onChange} isDisabled={isDisabled} className={styles.wrapper} aria-label="Enter 6-digit OTP code">
+      {/* Visual layer: Displays 6 digit boxes that show each character from the input value */}
+      <OTPVisualDisplay focused={focused} />
+
+      {/* Hidden input layer: Transparent input that receives all keyboard input */}
+      <div
+        className={css({
+          position: "absolute",
+          inset: "[0px]",
+          pointerEvents: "none",
+        })}>
+        <Input
+          name={name}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={(e) => {
+            setFocused(true);
+            // Prevent focus if form is submitting (browser might try to focus during validation)
+            if (isFormSubmitting()) {
+              blurIfFocused(e.target);
+            }
+          }}
+          onBlur={() => setFocused(false)}
+          onInvalid={(e) => {
+            // Prevent browser validation from focusing this hidden input
+            // Browser validation focuses invalid inputs, but our input is hidden and shouldn't be focused
+            e.preventDefault();
+            e.stopPropagation();
+            blurIfFocused(e.target as HTMLInputElement);
+          }}
+          onKeyDown={(e) => {
+            // When user presses Enter, trigger form submission via submit button
+            // This ensures proper form handling and prevents focus issues
+            if (e.key === "Enter") {
+              e.preventDefault();
+              e.stopPropagation();
+              triggerFormSubmit();
+            }
+          }}
+          inputMode="numeric"
+          maxLength={6}
+          autoComplete="one-time-code"
+          pattern={pattern}
+          tabIndex={-1}
+          aria-hidden="true"
+          data-form-field="otpCode"
+          className={styles.input}
+        />
+      </div>
+    </AriaTextField>
+  );
+};

--- a/src/field/OTPVisualDisplay.tsx
+++ b/src/field/OTPVisualDisplay.tsx
@@ -48,6 +48,7 @@ export const OTPVisualDisplay: FC<OTPVisualDisplayProps> = ({ focused }) => {
         </div>
       </div>
 
+      {/* A separator between the first and second group of digits */}
       <div role="separator" className={styles.separator}>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M5 12h14"></path>

--- a/src/field/OTPVisualDisplay.tsx
+++ b/src/field/OTPVisualDisplay.tsx
@@ -1,0 +1,70 @@
+import { useContext } from "react";
+import { InputContext } from "react-aria-components";
+
+import { otpTextField } from "../../styled-system/recipes";
+
+import type { FC } from "react";
+
+/**
+ * Internal component that displays the visual representation of OTP input digits.
+ *
+ * This component reads the value from the parent TextField's InputContext and displays
+ * each character in a separate styled box. It creates the visual illusion of 6 separate
+ * input fields while the actual input is a single hidden TextField.
+ *
+ * - Reads value from `InputContext` provided by the parent TextField
+ * - Displays characters at indices 0-5 in individual styled boxes
+ * - Shows active focus ring on the box corresponding to the current input position
+ * - Uses a separator (dash) between the 3rd and 4th digits for better readability
+ *
+ * Visual Focus Indication:
+ * The `focused` prop determines which digit box shows the active focus ring. The active
+ * box is determined by `value.length`, which represents the current cursor position:
+ * - value.length === 0 → first box is active
+ * - value.length === 1 → second box is active
+ * - ... and so on
+ */
+interface OTPVisualDisplayProps {
+  focused: boolean;
+}
+
+export const OTPVisualDisplay: FC<OTPVisualDisplayProps> = ({ focused }) => {
+  const inputProps = useContext(InputContext);
+  const value = (inputProps as { value?: string })?.value ?? "";
+
+  const styles = otpTextField();
+
+  return (
+    <>
+      <div className={styles.visualDisplay}>
+        <div className={styles.digitBox} data-active={value.length === 0 && focused ? "" : undefined}>
+          {value[0] ?? ""}
+        </div>
+        <div className={styles.digitBox} data-active={value.length === 1 && focused ? "" : undefined}>
+          {value[1] ?? ""}
+        </div>
+        <div className={styles.digitBox} data-active={value.length === 2 && focused ? "" : undefined}>
+          {value[2] ?? ""}
+        </div>
+      </div>
+
+      <div role="separator" className={styles.separator}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M5 12h14"></path>
+        </svg>
+      </div>
+
+      <div className={styles.visualDisplay}>
+        <div className={styles.digitBox} data-active={value.length === 3 && focused ? "" : undefined}>
+          {value[3] ?? ""}
+        </div>
+        <div className={styles.digitBox} data-active={value.length === 4 && focused ? "" : undefined}>
+          {value[4] ?? ""}
+        </div>
+        <div className={styles.digitBox} data-active={value.length >= 5 && focused ? "" : undefined}>
+          {value[5] ?? ""}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/field/otpTextField.recipe.ts
+++ b/src/field/otpTextField.recipe.ts
@@ -1,0 +1,111 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+/**
+ * Style variants for OTPTextField component.
+ * Creates a visual representation of 6 digit boxes with a single hidden input field.
+ *
+ * Slots:
+ * - wrapper: Main container that holds the visual display and hidden input
+ * - visualDisplay: Container for the digit boxes and separator
+ * - input: Hidden input field that receives keyboard input
+ * - digitBox: Individual styled box for each digit
+ * - separator: Visual separator between 3rd and 4th digit
+ */
+export const otpTextFieldRecipe = defineSlotRecipe({
+  className: "otpTextField",
+  description: "Style variants for OTP input component with 6 digit boxes",
+  slots: ["wrapper", "visualDisplay", "input", "digitBox", "separator"],
+  base: {
+    // Main wrapper container
+    wrapper: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: "2",
+      position: "relative",
+      cursor: "text",
+      userSelect: "none",
+      pointerEvents: "none",
+      height: "[36px]",
+      _disabled: {
+        opacity: "50",
+      },
+    },
+
+    // Visual display container for digit boxes
+    visualDisplay: {
+      display: "flex",
+      alignItems: "center",
+      gap: "0",
+    },
+
+    // Hidden input field
+    input: {
+      position: "absolute",
+      inset: "0",
+      width: "[calc(100% + 40px)]",
+      height: "full",
+      display: "flex",
+      textAlign: "left",
+      opacity: "1",
+      color: "transparent",
+      pointerEvents: "all",
+      background: "transparent",
+      caretColor: "transparent",
+      border: "[0px solid transparent]",
+      outline: "[transparent solid 0px]",
+      boxShadow: "[none]",
+      lineHeight: "[1]",
+      letterSpacing: "[-0.5em]",
+      fontSize: "[36px]",
+      fontFamily: "[monospace]",
+      fontVariantNumeric: "tabular-nums",
+      clipPath: "[inset(0px 40px 0px 0px)]",
+    },
+
+    // Individual digit box
+    digitBox: {
+      position: "relative",
+      display: "flex",
+      height: "11",
+      width: "11",
+      alignItems: "center",
+      justifyContent: "center",
+      borderTopWidth: "1",
+      borderBottomWidth: "1",
+      borderRightWidth: "1",
+      color: "text.primary",
+      borderStyle: "solid",
+      borderColor: "border.primary",
+      fontSize: "lg",
+      boxShadow: "[0 1px 2px 0 rgba(0, 0, 0, 0.05)]",
+      transitionProperty: "[box-shadow, color]",
+      _focusVisible: {
+        outline: "none",
+        borderColor: "border.brand",
+      },
+      _first: {
+        roundedLeft: "lg",
+        borderLeftWidth: "1",
+      },
+      _last: {
+        roundedRight: "lg",
+      },
+      "&[data-active]": {
+        zIndex: 10,
+        boxShadow: "[0 0 0 2px var(--colors-border-brand), 0 0 0 4px var(--colors-bg-primary-index)]",
+      },
+    },
+
+    // Separator between 3rd and 4th digit
+    separator: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+
+      "& svg": {
+        stroke: "text.white",
+      },
+    },
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export { ContentHeader } from "./contentheader/ContentHeader";
 export { SearchField } from "./field/SearchField";
 export { SliderField } from "./field/SliderField";
 export { SwitchField } from "./field/SwitchField";
+export { OTPTextField } from "./field/OTPTextField";
 export { TextArea } from "./field/TextArea";
 export { TextField } from "./field/TextField";
 export { ToggleSectionField } from "./field/ToggleSectionField";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a 6-digit `OTPTextField` with visual digit boxes, theme recipe integration, exports, and Storybook examples.
> 
> - **Components**:
>   - Add `OTPTextField` (`src/field/OTPTextField.tsx`) with hidden `Input`, visual digit boxes via `OTPVisualDisplay`, Enter-to-submit handling, and disabled support.
>   - Add internal `OTPVisualDisplay` (`src/field/OTPVisualDisplay.tsx`).
> - **Styling/Theme**:
>   - Add `otpTextField.recipe` (`src/field/otpTextField.recipe.ts`) and register in `cci-preset` under `theme.slotRecipes.otpTextField`.
> - **Exports**:
>   - Export `OTPTextField` from `src/index.ts`.
> - **Storybook**:
>   - Add `OTPTextField.stories.tsx` with default, partial, complete, disabled, and form-integration stories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f3eda58c577841510a0c80eede4dc6787a818c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->