### PR TITLE
feat: warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -452,7 +452,7 @@ export const App = () => {
 
       <Checkbox>Subscribe to newsletter</Checkbox>
 
-      <RadioGroup>
+      <RadioGroup aria-label="Vertical options">
         <Radio value="option1">Vertical Option 1</Radio>
         <Radio value="option2">Vertical Option 2</Radio>
         <Radio value="option3">Vertical Option 3</Radio>

--- a/src/field/OTPTextField.tsx
+++ b/src/field/OTPTextField.tsx
@@ -138,7 +138,6 @@ export const OTPTextField = ({ name, value, onChange, pattern, isDisabled }: OTP
           autoComplete="one-time-code"
           pattern={pattern}
           tabIndex={-1}
-          aria-hidden="true"
           data-form-field="otpCode"
           className={styles.input}
         />

--- a/src/radiogroup/RadioGroup.stories.tsx
+++ b/src/radiogroup/RadioGroup.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof RadioGroup>;
 
 export const Default: Story = {
   render: () => (
-    <RadioGroup>
+    <RadioGroup aria-label="Options">
       <Radio value="option1">Option 1</Radio>
       <Radio value="option2">Option 2</Radio>
       <Radio value="option3">Option 3</Radio>
@@ -35,7 +35,7 @@ export const Default: Story = {
 
 export const Disabled: Story = {
   render: () => (
-    <RadioGroup isDisabled>
+    <RadioGroup isDisabled aria-label="Disabled options">
       <Radio value="option1">Disabled Option 1</Radio>
       <Radio value="option2">Disabled Option 2</Radio>
       <Radio value="option3">Disabled Option 3</Radio>
@@ -45,7 +45,7 @@ export const Disabled: Story = {
 
 export const Invalid: Story = {
   render: () => (
-    <RadioGroup isInvalid>
+    <RadioGroup isInvalid aria-label="Invalid options">
       <Radio value="option1">Invalid Option 1</Radio>
       <Radio value="option2">Invalid Option 2</Radio>
       <Radio value="option3">Invalid Option 3</Radio>
@@ -55,7 +55,7 @@ export const Invalid: Story = {
 
 export const Required: Story = {
   render: () => (
-    <RadioGroup isRequired>
+    <RadioGroup isRequired aria-label="Required options">
       <Radio value="option1">Required Option 1</Radio>
       <Radio value="option2">Required Option 2</Radio>
       <Radio value="option3">Required Option 3</Radio>
@@ -65,7 +65,7 @@ export const Required: Story = {
 
 export const WithDefaultValue: Story = {
   render: () => (
-    <RadioGroup defaultValue="option2">
+    <RadioGroup defaultValue="option2" aria-label="Options with default value">
       <Radio value="option1">Option 1</Radio>
       <Radio value="option2">Option 2 (Default)</Radio>
       <Radio value="option3">Option 3</Radio>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `aria-label` to `RadioGroup` usages (app and Storybook) and removes `aria-hidden` from the hidden input in `OTPTextField`.
> 
> - **Accessibility**
>   - **RadioGroup**: Add `aria-label` to `RadioGroup` in `src/App.tsx` and all Storybook stories in `src/radiogroup/RadioGroup.stories.tsx` (Default, Disabled, Invalid, Required, WithDefaultValue).
>   - **OTPTextField**: Remove `aria-hidden` from the hidden `<Input>` in `src/field/OTPTextField.tsx`; retains `tabIndex={-1}` and other attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91443914d544277c94dbd1288a6f401ce306cdb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->