### PR TITLE
fix: select style

### DIFF
--- a/src/select/select.recipe.ts
+++ b/src/select/select.recipe.ts
@@ -98,10 +98,22 @@ export const selectRecipe = defineSlotRecipe({
       // Allows the value to take up the remaining space in the button
       flex: "1",
       textAlign: "left",
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+      textOverflow: "ellipsis",
     },
     popover: {
       // Makes the dropdown width match the button width
       width: "var(--trigger-width)",
+      minWidth: "var(--trigger-width)",
+      zIndex: "50",
+
+      // Styles for ListBox within the Popover
+      "& .listBox": {
+        width: "unset !important",
+        maxHeight: "inherit !important",
+        minHeight: "unset !important",
+      },
     },
   },
 


### PR DESCRIPTION
…ed popover dimensions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Truncates long selected value with ellipsis and updates popover width/z-index with listbox sizing overrides.
> 
> - **Select styles (`src/select/select.recipe.ts`)**
>   - **Value text**: Add `overflow: hidden`, `whiteSpace: nowrap`, `textOverflow: ellipsis` to truncate long labels.
>   - **Popover**: Add `minWidth: var(--trigger-width)` and `zIndex: 50`.
>   - **ListBox inside popover**: Override sizing with `width: unset !important`, `maxHeight: inherit !important`, `minHeight: unset !important`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99465eaaec8c2e9ba0143d62b4e38c32b2eaea2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->