### PR TITLE
feat(CAR-12): add default aria-label fallback to Button

### DIFF
--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -13,4 +13,21 @@ export type ButtonProps = WithoutClassName<AriaButtonProps> & Partial<ButtonVari
 /**
  * ARIA compliant button component that provides consistent styling, accessibility, variants, sizes, and width configurations.
  */
-export const Button: FC<ButtonProps> = ({ variant = "primary", width, size, ...props }) => <AriaButton className={button({ variant, width, size })} {...props} />;
+export const Button: FC<ButtonProps> = ({
+  variant = "primary",
+  width,
+  size,
+  children,
+  ...props
+}) => (
+  <AriaButton
+    className={button({ variant, width, size })}
+    aria-label={
+      props["aria-label"] ??
+      (typeof children === "string" ? children : undefined)
+    }
+    {...props}
+  >
+    {children}
+  </AriaButton>
+);


### PR DESCRIPTION
Pilot PR to validate the Linear → Claude Code → GitHub workflow.

Changes:
- Adds a default aria-label derived from children when not explicitly provided
- No breaking changes
- Improves accessibility consistency
