### PR TITLE
feat(CAR-13): set default Button type (Claude Code proposal)

### DIFF
--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -13,4 +13,5 @@ export type ButtonProps = WithoutClassName<AriaButtonProps> & Partial<ButtonVari
 /**
  * ARIA compliant button component that provides consistent styling, accessibility, variants, sizes, and width configurations.
  */
-export const Button: FC<ButtonProps> = ({ variant = "primary", width, size, ...props }) => <AriaButton className={button({ variant, width, size })} {...props} />;
+export const Button: FC<ButtonProps> = ({ variant = "primary", width, size, type = "button", ...props }) =>
+  <AriaButton className={button({ variant, width, size })} type={type} {...props} />;


### PR DESCRIPTION
Pilot PR to validate Claude Code participation in the workflow.

This change was proposed by Claude Code after reviewing the Button component.

Change:
- Sets default `type="button"` to prevent unintended form submissions
- Keeps behavior overridable for submit buttons
- No breaking changes

Rationale:
Buttons default to `type="submit"` inside forms, which can cause accidental
submissions for keyboard and assistive technology users.
