### PR TITLE
fix/UPS-130-listbox-styling

### DIFF
--- a/src/listbox/listBox.recipe.ts
+++ b/src/listbox/listBox.recipe.ts
@@ -7,6 +7,7 @@ export const listBoxRecipe = defineRecipe({
   base: {
     // Enables scrolling when options exceed the listbox height, keeping the UI compact and usable
     overflow: "auto",
+    borderColor: "border.primary",
   },
 
   variants: {
@@ -16,13 +17,12 @@ export const listBoxRecipe = defineRecipe({
         display: "block",
         // Makes the listbox expand to fill its parent container's width, preventing awkward partial-width dropdowns
         width: "full",
-        // Creates a clean white background to ensure options are easily readable against any page background
-        bg: "text.white",
+        // Creates a clean background to ensure options are easily readable against any page background
+        bg: "bg.primary.index",
         // Softens the corners to match modern UI design patterns and provide visual harmony with other components
         borderRadius: "lg",
         border: "1",
         borderStyle: "solid",
-        borderColor: "border.secondary._alt",
 
         //TODO This feels very limited, should be a prop or something where it can be set per use case
         maxHeight: "100",


### PR DESCRIPTION
## Summary

- Add `borderColor: border.primary` to ListBox base styles for consistent border theming
- Change background from `text.white` to `bg.primary.index` in default variant for proper theme integration
- Remove redundant `borderColor` from default variant (now inherited from base)

## Test plan

- [ ] Verify ListBox component renders with correct background color (`bg.primary.index`)
- [ ] Verify ListBox border uses `border.primary` color
- [ ] Test in both light and dark themes if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `ListBox` styling with theme tokens.
> 
> - Set base `borderColor` to `border.primary` for consistent theming
> - Switch default variant `bg` from `text.white` to `bg.primary.index`
> - Remove redundant `borderColor` from default variant (now inherited from base)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be73aeb24df4d2430f0f337b83723e65ad397b1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->